### PR TITLE
missing dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,6 +14,9 @@
 {
     "type": "git",
     "url": "https://github.com/gmag11/NtpClient"
-}
+},
+    "dependencies": {
+        "Time": "PaulStoffregen/Time"
+    }
 }
 


### PR DESCRIPTION
This ensures Time lib is loaded automatically when building project with platformio, so there is no need to add it to project's platformio.ini.