### PR TITLE
Calculate daylight and timezone changes without triggering a sync

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,9 +14,6 @@
 {
     "type": "git",
     "url": "https://github.com/gmag11/NtpClient"
-},
-    "dependencies": {
-        "Time": "PaulStoffregen/Time"
     }
 }
 


### PR DESCRIPTION
These changes do the calculations for timezone and daylight changes **only** if the time has already been synced. This has two benefits:

* Prevents multiple UDP requests in the begin method
* Allows changing those two parameters without triggering a UDP requests (setTimezone was explicitly doing a getTime)

Not doing the calculations if the time is not set does not have an impact since they are already done in the decodeNtpMessage method.