### PR TITLE
Add support for USA DST calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ artifacts/
 *.pidb
 *.svclog
 *.scc
+*.gch
 
 # Chutzpah Test files
 _Chutzpah*

--- a/examples/NTPDSTTest/.gitignore
+++ b/examples/NTPDSTTest/.gitignore
@@ -1,0 +1,3 @@
+.pioenvs
+.piolibdeps
+lib

--- a/examples/NTPDSTTest/NTPDSTTest.ino
+++ b/examples/NTPDSTTest/NTPDSTTest.ino
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 German Martin (gmag11@gmail.com). All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met :
+
+1. Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list
+of conditions and the following disclaimer in the documentation and / or other materials
+provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ''AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.IN NO EVENT SHALL <COPYRIGHT HOLDER> OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT(INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the
+authors and should not be interpreted as representing official policies, either expressed
+or implied, of German Martin
+*/
+
+/*
+ Name:		NTPDSTTest.ino
+ Created:	13/03/2018
+ Author:	xose.perez@gmail.com
+ Editor:	http://www.platformio.org
+*/
+
+#include <TimeLib.h>
+#include <NtpClientLib.h>
+#include <assert.h>
+
+void test(bool expected) {
+
+    char buffer[32];
+    snprintf(
+        buffer, sizeof(buffer),
+        "Testing %04d/%02d/%02d %02d:%02d:%02d - ",
+        year(), month(), day(), hour(), minute(), second()
+    );
+    Serial.print(buffer);
+    Serial.println(NTP.isSummerTime() == expected ? "OK" : "FAIL");
+
+}
+
+void setup () {
+
+    Serial.begin(115200);
+    while (!Serial);
+
+    NTP.setDayLight(true);
+
+    // EU Test
+    NTP.setDSTZone(DST_ZONE_EU);
+    NTP.setTimeZone(1, 0);
+    Serial.println();
+    Serial.println("Europe DST");
+    Serial.println("------------------------");
+    setTime(0,0,0,15,02,2018); test(false);
+    setTime(0,0,0,15,04,2018); test(true);
+    setTime(0,0,0,01,03,2018); test(false);
+    setTime(0,0,0,30,03,2018); test(true);
+    setTime(1,0,0,25,03,2018); test(false);
+    setTime(3,0,0,25,03,2018); test(true);
+    setTime(0,0,0,01,10,2018); test(true);
+    setTime(0,0,0,30,10,2018); test(false);
+    setTime(1,0,0,28,10,2018); test(true);
+    setTime(3,0,0,28,10,2018); test(false);
+
+    // USA Test
+    NTP.setDSTZone(DST_ZONE_USA);
+    NTP.setTimeZone(-6, 0);
+    Serial.println();
+    Serial.println("USA DST");
+    Serial.println("------------------------");
+    setTime(0,0,0,15,02,2018); test(false);
+    setTime(0,0,0,15,04,2018); test(true);
+    setTime(0,0,0,01,03,2018); test(false);
+    setTime(0,0,0,30,03,2018); test(true);
+    setTime(1,0,0,11,03,2018); test(false);
+    setTime(3,0,0,11,03,2018); test(true);
+    setTime(0,0,0,01,11,2018); test(true);
+    setTime(0,0,0,30,11,2018); test(false);
+    setTime(1,0,0,04,11,2018); test(true);
+    setTime(3,0,0,04,11,2018); test(false);
+}
+
+void loop () {}

--- a/examples/NTPDSTTest/platformio.ini
+++ b/examples/NTPDSTTest/platformio.ini
@@ -1,0 +1,10 @@
+[platformio]
+src_dir = .
+lib_dir = ../..
+
+[env:leonardo]
+platform = atmelavr
+board = leonardo
+framework = arduino
+lib_deps =
+    https://github.com/xoseperez/Time

--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -75,7 +75,9 @@ char* NTPClient::getNtpServerNamePtr () {
 bool NTPClient::setDSTZone (uint8_t dstZone) {
     if (dstZone < DST_ZONE_COUNT) {
         _dstZone = dstZone;
+        return true;
     }
+    return false;
 }
 
 uint8_t NTPClient::getDSTZone() {

--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -25,9 +25,9 @@ The views and conclusions contained in the software and documentation are those 
 authors and should not be interpreted as representing official policies, either expressed
 or implied, of German Martin
 */
-// 
-// 
-// 
+//
+//
+//
 
 #include "NtpClientLib.h"
 
@@ -70,6 +70,16 @@ String NTPClient::getNtpServerName () {
 
 char* NTPClient::getNtpServerNamePtr () {
     return _ntpServerName;
+}
+
+bool NTPClient::setDSTZone (uint8_t dstZone) {
+    if (dstZone < DST_ZONE_COUNT) {
+        _dstZone = dstZone;
+    }
+}
+
+uint8_t NTPClient::getDSTZone() {
+    return _dstZone;
 }
 
 bool NTPClient::setTimeZone (int8_t timeZone, int8_t minutes) {
@@ -365,19 +375,49 @@ time_t NTPClient::getFirstSync () {
     return _firstSync;
 }
 
-bool NTPClient::summertime (int year, byte month, byte day, byte hour, byte tzHours)
-// input parameters: "normal time" for year, month, day, hour and tzHours (0=UTC, 1=MEZ)
+bool NTPClient::summertime (int year, byte month, byte day, byte hour, byte weekday, byte tzHours)
+// input parameters: "normal time" for year, month, day, hour, weekday and tzHours (0=UTC, 1=MEZ)
 {
-    if ((month < 3) || (month > 10)) return false; // keine Sommerzeit in Jan, Feb, Nov, Dez
-    if ((month > 3) && (month < 10)) return true; // Sommerzeit in Apr, Mai, Jun, Jul, Aug, Sep
-    if (month == 3 && (hour + 24 * day) >= (1 + tzHours + 24 * (31 - (5 * year / 4 + 4) % 7)) || month == 10 && (hour + 24 * day) < (1 + tzHours + 24 * (31 - (5 * year / 4 + 1) % 7)))
-        return true;
-    else
-        return false;
+
+    if (DST_ZONE_EU == _dstZone) {
+        if ((month < 3) || (month > 10)) return false; // keine Sommerzeit in Jan, Feb, Nov, Dez
+        if ((month > 3) && (month < 10)) return true; // Sommerzeit in Apr, Mai, Jun, Jul, Aug, Sep
+        if (month == 3 && (hour + 24 * day) >= (1 + tzHours + 24 * (31 - (5 * year / 4 + 4) % 7)) || month == 10 && (hour + 24 * day) < (1 + tzHours + 24 * (31 - (5 * year / 4 + 1) % 7)))
+            return true;
+        else
+            return false;
+    }
+
+    if (DST_ZONE_USA == _dstZone) {
+
+        // always false for Jan, Feb and Dec
+        if ((month < 3) || (month > 11)) return false;
+
+        // always true from Apr to Oct
+        if ((month > 3) && (month < 11)) return true;
+
+        // first sunday of current month
+        uint8_t first_sunday = (7 + day - weekday) % 7 + 1;
+
+        // Starts at 2:00 am on the second sunday of Mar
+        if (3 == month) {
+            if (day < 7 + first_sunday) return false;
+            if (day > 7 + first_sunday) return true;
+            return (hour > 2);
+        }
+
+        // Ends a 2:00 am on the first sunday of Nov
+        // We are only getting here if its Nov
+        if (day < first_sunday) return true;
+        if (day > first_sunday) return false;
+        return (hour < 2);
+
+    }
+
 }
 
 boolean NTPClient::isSummerTimePeriod (time_t moment) {
-    return summertime (year (), month (), day (), hour (), getTimeZone ());
+    return summertime (year (), month (), day (), hour (), weekday (), getTimeZone ());
 }
 
 void NTPClient::setLastNTPSync (time_t moment) {
@@ -389,7 +429,7 @@ uint16_t NTPClient::getNTPTimeout () {
 }
 
 boolean NTPClient::setNTPTimeout (uint16_t milliseconds) {
-    
+
     if (milliseconds >= MIN_NTP_TIMEOUT) {
         ntpTimeout = milliseconds;
         DEBUGLOG ("Set NTP timeout to %u ms\n", milliseconds);
@@ -397,7 +437,7 @@ boolean NTPClient::setNTPTimeout (uint16_t milliseconds) {
     }
     DEBUGLOG ("NTP timeout should be higher than %u ms. You've tried to set %u ms\n", MIN_NTP_TIMEOUT, milliseconds);
     return false;
-    
+
 }
 
 
@@ -414,7 +454,7 @@ time_t NTPClient::decodeNtpMessage (char *messageBuffer) {
     time_t timeTemp = secsSince1900 - SEVENTY_YEARS + _timeZone * SECS_PER_HOUR + _minutesOffset * SECS_PER_MIN;
 
     if (_daylight) {
-        if (summertime (year (timeTemp), month (timeTemp), day (timeTemp), hour (timeTemp), _timeZone)) {
+        if (summertime (year (timeTemp), month (timeTemp), day (timeTemp), hour (timeTemp), weekday (timeTemp), _timeZone)) {
             timeTemp += SECS_PER_HOUR;
             DEBUGLOG ("Summer Time\n");
         } else {

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -66,10 +66,15 @@ using namespace placeholders;
 
 #define DEFAULT_NTP_SERVER "pool.ntp.org" // Default international NTP server. I recommend you to select a closer server to get better accuracy
 #define DEFAULT_NTP_PORT 123 // Default local udp port. Select a different one if neccesary (usually not needed)
-#define DEFAULT_NTP_INTERVAL 1800 // Default sync interval 30 minutes 
+#define DEFAULT_NTP_INTERVAL 1800 // Default sync interval 30 minutes
 #define DEFAULT_NTP_SHORTINTERVAL 15 // Sync interval when sync has not been achieved. 15 seconds
 #define DEFAULT_NTP_TIMEZONE 0 // Select your local time offset. 0 if UTC time has to be used
 #define MIN_NTP_TIMEOUT 100 // Minumum admisible ntp timeout
+
+#define DST_ZONE_EU             (0)
+#define DST_ZONE_USA            (1)
+#define DST_ZONE_COUNT          (2)
+#define DEFAULT_DST_ZONE        DST_ZONE_EU
 
 const int NTP_PACKET_SIZE = 48; // NTP time is in the first 48 bytes of message
 
@@ -203,6 +208,19 @@ public:
     * @param[out] Minutes offset (plus or minus) added to hourly offset.
     */
     int8_t getTimeZoneMinutes ();
+
+    /**
+    * Sets DST zone.
+    * @param[in] New DST zone (DST_ZONE_EU || DST_ZONE_USA).
+    * @param[out] True if everything went ok.
+    */
+    bool setDSTZone (uint8_t dstZone);
+
+    /**
+    * Gets DST zone.
+    * @param[out] DST zone.
+    */
+    uint8_t getDSTZone();
 
     /**
     * Stops time synchronization.
@@ -380,6 +398,7 @@ protected:
     bool _daylight;             ///< Does this time zone have daylight saving?
     int8_t _timeZone = 0;       ///< Keep track of set time zone offset
     int8_t _minutesOffset = 0;   ///< Minutes offset for time zones with decimal numbers
+    uint8_t _dstZone = DEFAULT_DST_ZONE; ///< Daylight save time zone
     char* _ntpServerName;       ///< Name of NTP server on Internet or LAN
     int _shortInterval = DEFAULT_NTP_SHORTINTERVAL;         ///< Interval to set periodic time sync until first synchronization.
     int _longInterval = DEFAULT_NTP_INTERVAL;          ///< Interval to set periodic time sync
@@ -401,10 +420,11 @@ protected:
     * @param[in] Month.
     * @param[in] Day.
     * @param[in] Hour.
+    * @param[in] Weekday (1 for sunday).
     * @param[in] Time zone offset.
     * @param[out] true if date and time are inside summertime period.
     */
-    bool summertime (int year, byte month, byte day, byte hour, byte tzHours);
+    bool summertime (int year, byte month, byte day, byte hour, byte weekday, byte tzHours);
 
     /**
     * Helper function to add leading 0 to hour, minutes or seconds if < 10.


### PR DESCRIPTION
This commit adds two new methods: `uint8_t getDSTZone()` and `bool setDSTZone(unit8_t)` to be able to specify the DST calculation method. Currently, DST_ZONE_EU (the default one) and DST_ZONE_USA are defined.

A testing example is included to ensure valid output.

Usage:

```
NTP.setDSTZone(DST_ZONE_USA);
```
