### PR TITLE
Update NTPClientLib.cpp

### DIFF
--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -353,7 +353,7 @@ bool NTPClient::summertime (int year, byte month, byte day, byte hour, byte tzHo
 {
     if ((month < 3) || (month > 10)) return false; // keine Sommerzeit in Jan, Feb, Nov, Dez
     if ((month > 3) && (month < 10)) return true; // Sommerzeit in Apr, Mai, Jun, Jul, Aug, Sep
-    if (month == 3 && (hour + 24 * day) >= (1 + tzHours + 24 * (31 - (5 * year / 4 + 4) % 7)) || month == 10 && (hour + 24 * day) < (1 + tzHours + 24 * (31 - (5 * year / 4 + 1) % 7)))
+    if ((month == 3 && (hour + 24 * day) >= (1 + tzHours + 24 * (31 - (5 * year / 4 + 4) % 7))) || (month == 10 && (hour + 24 * day) < (1 + tzHours + 24 * (31 - (5 * year / 4 + 1) % 7))))
         return true;
     else
         return false;


### PR DESCRIPTION
fixed () around ||
default CFLAGS "-Wno-logical-op-parentheses" say this was an error.