### PR TITLE
store all time zone parameter to evaluate possible DST

### DIFF
--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -192,7 +192,7 @@ time_t NTPClient::getTime () {
                                     //if (dnsResult == 1) { //If DNS lookup resulted ok
     sendNTPpacket (getNtpServerName ().c_str (), udp);
     uint32_t beginWait = millis ();
-    while (millis () - beginWait < NTP_TIMEOUT) {
+    while (millis () - beginWait < ntpTimeout ) {
         int size = udp->parsePacket ();
         if (size >= NTP_PACKET_SIZE) {
             DEBUGLOG ("-- Receive NTP Response\n");
@@ -499,6 +499,22 @@ void NTPClient::setLastNTPSync (time_t moment) {
     _lastSyncd = moment;
 }
 
+uint16_t NTPClient::getNTPTimeout () {
+    return ntpTimeout;
+}
+
+boolean NTPClient::setNTPTimeout (uint16_t milliseconds) {
+
+    if (milliseconds >= MIN_NTP_TIMEOUT) {
+        ntpTimeout = milliseconds;
+        DEBUGLOG ("Set NTP timeout to %u ms\n", milliseconds);
+        return true;
+    }
+    DEBUGLOG ("NTP timeout should be higher than %u ms. You've tried to set %u ms\n", MIN_NTP_TIMEOUT, milliseconds);
+    return false;
+
+}
+
 time_t NTPClient::decodeNtpMessage (char *messageBuffer) {
     unsigned long secsSince1900;
     // convert four bytes starting at location 40 to a long integer
@@ -510,6 +526,7 @@ time_t NTPClient::decodeNtpMessage (char *messageBuffer) {
 #define SEVENTY_YEARS 2208988800UL
     time_t timeTemp = secsSince1900 - SEVENTY_YEARS;
     timeTemp += (_tzOffset) *  SECS_PER_MIN;
+
     _useDST = false;
 
     if (_tzDSTName != NULL ) {

--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -72,23 +72,67 @@ char* NTPClient::getNtpServerNamePtr () {
     return _ntpServerName;
 }
 
-bool NTPClient::setTimeZone (int8_t timeZone, int8_t minutes) {
-    if ((timeZone >= -12) && (timeZone <= 14) && (minutes >= -59) && (minutes <= 59)) {
-        // Temporarily set time to new time zone, before trying to synchronize
-        int8_t timeDiff = timeZone - _timeZone;
-        _timeZone = timeZone;
-        _minutesOffset = minutes;
-        setTime (now () + timeDiff * SECS_PER_HOUR + minutes * SECS_PER_MIN);
-        if (udp && (timeStatus () != timeNotSet)) {
-            setTime (getTime ());
-        }
-        DEBUGLOG ("NTP time zone set to: %d\r\n", timeZone);
-        return true;
+#define MINS_PER_HOUR 60
+
+int NTPClient::setTimeZone ( int16_t  timeZoneOffset,     // full offset from GMT 0 in minutes 
+			      char * timeZoneName,
+			      char * timeZoneDSTName,    // NULL if disable
+			      int16_t  timeZoneDSTOffset,  // full offset from GMT 0 in minutes  for DST
+			      uint8_t dstStartMonth,     // start of Summer time if enabled  Month 1 - 12, 0 disabled dst
+			      uint8_t dstStartWeek,      // start of Summer time if enabled Week 1 - 5: (5 means last)
+			      uint8_t dstStartDay,       // start of Summer time if enabled Day 1- 7  (1- Sun)
+			      uint16_t dstStartMin,     // start of Summer time if enabled in minutes
+			      uint8_t dstEndMonth,       // end of Summer time if enabled  Month 1 - 12
+			      uint8_t dstEndWeek,        // end of Summer time if enabled Week 1 - 5: (5 means last)
+			      uint8_t dstEndDay,         // end of Summer time if enabled Day 1-7  (1- Sun)
+			      uint16_t dstEndMin) {       // end of Summer time if enabled in minutes
+
+  if ( timeZoneOffset < -12 * MINS_PER_HOUR  || timeZoneOffset > 14*MINS_PER_HOUR ) return 1;
+  if ( timeZoneDSTOffset < -12 * MINS_PER_HOUR  || timeZoneDSTOffset > 14*MINS_PER_HOUR ) return 2;
+  if ( dstStartMonth  < 1  || dstStartMonth > 12  ) return 3;
+  if ( dstStartWeek  < 1  || dstStartWeek > 5  ) return 4;
+  if ( dstStartDay  < 0  || dstStartDay > 6  ) return 5;
+  if ( dstStartMin  > 24*MINS_PER_HOUR-1  ) return 6;
+  if ( dstEndMonth  < 1  || dstEndMonth > 12  ) return 7;
+  if ( dstEndWeek  < 1  || dstEndWeek > 5  ) return 8;
+  if ( dstEndDay  < 0  || dstEndDay > 6  ) return 9;
+  if ( dstEndMin  > 24*MINS_PER_HOUR-1  ) return 10;
+  int16_t currOffset = (_useDST) ? _tzDSTOffset : _tzOffset;
+  _tzName = timeZoneName;
+  _tzDSTName = timeZoneDSTName;
+  _tzDSTOffset = timeZoneDSTOffset;
+  _tzOffset = timeZoneOffset;
+  _tzDSTOffset = timeZoneDSTOffset;
+  _dstStartMonth = dstStartMonth;
+  _dstStartWeek  = dstStartWeek;
+  _dstStartDay   = dstStartDay;
+  _dstStartMin   = dstStartMin;
+  _dstEndMonth = dstEndMonth;
+  _dstEndWeek  = dstEndWeek;
+  _dstEndDay   = dstEndDay;
+  _dstEndMin   = dstEndMin;
+  _useDST = false;
+  setTime (now () + (_tzOffset - currOffset) * SECS_PER_MIN);
+  DEBUGLOG ("NTP time zone set to: %d:02d\r\n", _tzOffset < 0 ? "-" : "", abs(_tzOffset)/MINS_PER_HOUR, abs(_tzOffset) % MINS_PER_HOUR);
+  if (_tzDSTName != NULL ) {
+    if (isSummerTimePeriod ( now() ) ) {
+      setTime (now () + (_tzDSTOffset - _tzOffset) * SECS_PER_MIN);
+      _useDST = true;
+      DEBUGLOG ("NTP adjust for DST, time zone set to: %s%d:02d\r\n",
+		_tzDSTOffset < 0 ? "-" : "", abs(_tzDSTOffset)/MINS_PER_HOUR, abs(_tzDSTOffset) % MINS_PER_HOUR);
     }
-    return false;
+  }
+  return 0;
+  
 }
 
-boolean sendNTPpacket (const char* address, UDP *udp) {
+bool NTPClient::setTimeZone (int8_t timeZone, int8_t minutes) {
+
+  int16_t totalOffset = timeZone * MINS_PER_HOUR + minutes;
+  return setTimeZone( totalOffset ) == 0;
+}
+
+bool sendNTPpacket (const char* address, UDP *udp) {
     uint8_t ntpPacketBuffer[NTP_PACKET_SIZE]; //Buffer to store request message
 
                                            // set all bytes in the buffer to 0
@@ -110,6 +154,14 @@ boolean sendNTPpacket (const char* address, UDP *udp) {
     udp->write (ntpPacketBuffer, NTP_PACKET_SIZE);
     udp->endPacket ();
     return true;
+}
+
+int16_t NTPClient::getOffset () {
+  
+  if ( _useDST == true ) {
+    return _tzDSTOffset;
+  }
+  return _tzOffset;
 }
 
 time_t NTPClient::getTime () {
@@ -172,11 +224,11 @@ time_t NTPClient::getTime () {
 }
 
 int8_t NTPClient::getTimeZone () {
-    return _timeZone;
+    return _tzOffset/MINS_PER_HOUR;
 }
 
 int8_t NTPClient::getTimeZoneMinutes () {
-    return _minutesOffset;
+    return _tzOffset%MINS_PER_HOUR;
 }
 
 /*void NTPClient::setLastNTPSync(time_t moment) {
@@ -270,18 +322,21 @@ int NTPClient::getShortInterval () {
 }
 
 void NTPClient::setDayLight (bool daylight) {
-    _daylight = daylight;
     DEBUGLOG ("--Set daylight saving %s\n", daylight ? "ON" : "OFF");
     setTime (getTime ());
 }
 
 bool NTPClient::getDayLight () {
-    return _daylight;
+  return (_tzDSTName != NULL)? true : false ;
 }
 
 String NTPClient::getTimeStr (time_t moment) {
-    char timeStr[10];
-    sprintf (timeStr, "%02d:%02d:%02d", hour (moment), minute (moment), second (moment));
+    char timeStr[15];
+    if ( _tzName == NULL ) {
+      sprintf (timeStr, "%02d:%02d:%02d", hour (moment), minute (moment), second (moment));
+    } else {
+      sprintf (timeStr, "%02d:%02d:%02d %s", hour (moment), minute (moment), second (moment), (_useDST) ? _tzDSTName : _tzName );
+    }
 
     return timeStr;
 }
@@ -295,6 +350,10 @@ String NTPClient::getDateStr (time_t moment) {
 
 String NTPClient::getTimeDateString (time_t moment) {
     return getTimeStr (moment) + " " + getDateStr (moment);
+}
+
+String NTPClient::getDateTimeString (time_t moment) {
+    return getDateStr (moment) + " " + getTimeStr (moment);
 }
 
 time_t NTPClient::getLastNTPSync () {
@@ -348,20 +407,91 @@ time_t NTPClient::getFirstSync () {
     return _firstSync;
 }
 
-bool NTPClient::summertime (int year, byte month, byte day, byte hour, byte tzHours)
-// input parameters: "normal time" for year, month, day, hour and tzHours (0=UTC, 1=MEZ)
+time_t getDstDate ( int dst_year, uint8_t dst_month, uint8_t dst_day, uint8_t dst_week, uint16_t dst_min ) {
+   tmElements_t base;
+   time_t base_month;;
+   uint8_t wday; // first_day_of_month
+    char buffer[100];
+
+   base.Second = 0;
+   base.Minute = dst_min % MINS_PER_HOUR;
+   base.Hour = dst_min/MINS_PER_HOUR;
+   base.Day = 1;
+   base.Month = dst_month;
+   base.Year = CalendarYrToTm(dst_year);
+   if ( dst_week == 5 ) { // last
+     base.Month += 1; // next month
+   }
+   base_month = makeTime(base);
+   if ( dst_week == 5 ) { // last
+     base_month -= SECS_PER_DAY; // now last day of month
+   }
+   wday = dayOfWeek(base_month);
+   if ( dst_week < 5 ) {
+    base_month +=    (SECS_PER_DAY)*((dst_week-1)*7+((dst_day+7-wday)%7));
+  } else {
+    base_month -=    (SECS_PER_DAY)*(((wday+7-dst_day)%7));
+  }
+  return base_month;
+  
+ }
+
+bool NTPClient::isSummerTimePeriod (time_t moment)
+// input parameters: time to be tested
 {
-    if ((month < 3) || (month > 10)) return false; // keine Sommerzeit in Jan, Feb, Nov, Dez
-    if ((month > 3) && (month < 10)) return true; // Sommerzeit in Apr, Mai, Jun, Jul, Aug, Sep
-    if ((month == 3 && (hour + 24 * day) >= (1 + tzHours + 24 * (31 - (5 * year / 4 + 4) % 7))) || (month == 10 && (hour + 24 * day) < (1 + tzHours + 24 * (31 - (5 * year / 4 + 1) % 7))))
-        return true;
-    else
-        return false;
+    time_t end_dst;
+    time_t start_dst;
+    int n_year;
+
+    n_year = year(moment);
+
+    if ( _tzDSTName == NULL ) return false; // No DST
+    start_dst = getDstDate ( n_year, _dstStartMonth, _dstStartDay, _dstStartWeek, _dstStartMin);
+    end_dst = getDstDate ( n_year, _dstEndMonth, _dstEndDay, _dstEndWeek, _dstEndMin);
+    return true;
+
+    if (start_dst < end_dst) { // Northern
+      return ((moment >= start_dst)  && (moment < end_dst))  ? true : false;
+    } else { // Southern
+      return ((moment > end_dst)  && (moment <= start_dst))  ? false : true;
+    }
 }
 
-boolean NTPClient::isSummerTimePeriod (time_t moment) {
-    return summertime (year (), month (), day (), hour (), getTimeZone ());
+bool NTPClient::summertime (int n_year, byte n_month, byte n_day, byte n_hour)
+// input parameters: "normal time" for year, month, day, hour
+{
+    uint8_t s_month;
+    uint8_t s_week;
+    uint8_t s_day;
+    uint8_t e_month;
+    uint8_t e_week;
+    uint8_t e_day;
+    uint8_t dst_hour;
+    tmElements_t cur_tm;
+    time_t cur;
+    time_t end_dst;
+    time_t start_dst;
+
+    if ( _tzDSTName == NULL ) return false; // No DST
+
+    cur_tm.Second = 0;
+    cur_tm.Minute = 1;
+    cur_tm.Hour  = (uint8_t)n_hour;
+    cur_tm.Day   = (uint8_t)n_day;
+    cur_tm.Month = (uint8_t)n_month;
+    cur_tm.Year  = (uint8_t)CalendarYrToTm(n_year);
+    cur = makeTime(cur_tm);
+    return isSummerTimePeriod (cur);
 }
+
+time_t NTPClient::getDstStart () {
+  return getDstDate ( year(), _dstStartMonth, _dstStartDay, _dstStartWeek, _dstStartMin);
+}
+
+time_t NTPClient::getDstEnd () {
+  return getDstDate ( year(), _dstEndMonth, _dstEndDay, _dstEndWeek, _dstEndMin);
+}
+
 
 void NTPClient::setLastNTPSync (time_t moment) {
     _lastSyncd = moment;
@@ -376,11 +506,14 @@ time_t NTPClient::decodeNtpMessage (char *messageBuffer) {
     secsSince1900 |= (unsigned long)messageBuffer[43];
 
 #define SEVENTY_YEARS 2208988800UL
-    time_t timeTemp = secsSince1900 - SEVENTY_YEARS + _timeZone * SECS_PER_HOUR + _minutesOffset * SECS_PER_MIN;
+    time_t timeTemp = secsSince1900 - SEVENTY_YEARS;
+    timeTemp += (_tzOffset) *  SECS_PER_MIN;
+    _useDST = false;
 
-    if (_daylight) {
-        if (summertime (year (timeTemp), month (timeTemp), day (timeTemp), hour (timeTemp), _timeZone)) {
-            timeTemp += SECS_PER_HOUR;
+    if (_tzDSTName != NULL ) {
+        if (summertime (year (timeTemp), month (timeTemp), day (timeTemp), hour (timeTemp) )) {
+	  timeTemp += (_tzDSTOffset - _tzOffset) *  SECS_PER_MIN;
+	  _useDST = true;
             DEBUGLOG ("Summer Time\n");
         } else {
             DEBUGLOG ("Winter Time\n");

--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -88,15 +88,17 @@ int NTPClient::setTimeZone ( int16_t  timeZoneOffset,     // full offset from GM
 			      uint16_t dstEndMin) {       // end of Summer time if enabled in minutes
 
   if ( timeZoneOffset < -12 * MINS_PER_HOUR  || timeZoneOffset > 14*MINS_PER_HOUR ) return 1;
-  if ( timeZoneDSTOffset < -12 * MINS_PER_HOUR  || timeZoneDSTOffset > 14*MINS_PER_HOUR ) return 2;
-  if ( dstStartMonth  < 1  || dstStartMonth > 12  ) return 3;
-  if ( dstStartWeek  < 1  || dstStartWeek > 5  ) return 4;
-  if ( dstStartDay  < 0  || dstStartDay > 6  ) return 5;
-  if ( dstStartMin  > 24*MINS_PER_HOUR-1  ) return 6;
-  if ( dstEndMonth  < 1  || dstEndMonth > 12  ) return 7;
-  if ( dstEndWeek  < 1  || dstEndWeek > 5  ) return 8;
-  if ( dstEndDay  < 0  || dstEndDay > 6  ) return 9;
-  if ( dstEndMin  > 24*MINS_PER_HOUR-1  ) return 10;
+  if ( timeZoneDSTName != NULL ) {
+    if ( timeZoneDSTOffset < -12 * MINS_PER_HOUR  || timeZoneDSTOffset > 14*MINS_PER_HOUR ) return 2;
+    if ( dstStartMonth  < 1  || dstStartMonth > 12  ) return 3;
+    if ( dstStartWeek  < 1  || dstStartWeek > 5  ) return 4;
+    if ( dstStartDay  < 0  || dstStartDay > 6  ) return 5;
+    if ( dstStartMin  > 24*MINS_PER_HOUR-1  ) return 6;
+    if ( dstEndMonth  < 1  || dstEndMonth > 12  ) return 7;
+    if ( dstEndWeek  < 1  || dstEndWeek > 5  ) return 8;
+    if ( dstEndDay  < 0  || dstEndDay > 6  ) return 9;
+    if ( dstEndMin  > 24*MINS_PER_HOUR-1  ) return 10;
+  }
   int16_t currOffset = (_useDST) ? _tzDSTOffset : _tzOffset;
   _tzName = timeZoneName;
   _tzDSTName = timeZoneDSTName;
@@ -129,7 +131,7 @@ int NTPClient::setTimeZone ( int16_t  timeZoneOffset,     // full offset from GM
 bool NTPClient::setTimeZone (int8_t timeZone, int8_t minutes) {
 
   int16_t totalOffset = timeZone * MINS_PER_HOUR + minutes;
-  return setTimeZone( totalOffset ) == 0;
+  return setTimeZone( totalOffset, "?" ) == 0;
 }
 
 bool sendNTPpacket (const char* address, UDP *udp) {

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -206,12 +206,12 @@ public:
 		      uint8_t dstStartWeek = 1,      // start of Summer time if enabled Week 1 - 5: (5 means last)
 		      uint8_t dstStartDay = 1,       // start of Summer time if enabled Day 0- 6  (0- Sun)
 		      // if startDay == 7, then sum of (StartMonth+StartWeek) is the day of the year DST starts
-		      uint16_t dstStartMin = 0,     // start of Summer time if enabled in minutes
+		      int16_t dstStartMin = 0,     // start of Summer time if enabled in minutes
 		      uint8_t dstEndMonth = 1,       // end of Summer time if enabled  Month 1 - 12
 		      uint8_t dstEndWeek = 1,        // end of Summer time if enabled Week 1 - 5: (5 means last)
 		      uint8_t dstEndDay = 1,         // end of Summer time if enabled Day 0-6  (0- Sun)
 		      // if EndDay == 7, then sum of (EndMonth+EndWeek) is the day of the year DST ends
-		      uint16_t dstEndMin = 0);       // end of Summer time if enabled in minutes
+		      int16_t dstEndMin = 0);       // end of Summer time if enabled in minutes
 
     /**
     * Gets timezone.
@@ -438,11 +438,11 @@ protected:
     uint8_t  _dstStartMonth = 0;     // start of Summer time if enabled  Month 1 - 12, 0 disabled dst
     uint8_t  _dstStartWeek = 0;      // start of Summer time if enabled Week 1 - 5: (5 means last)
     uint8_t  _dstStartDay = 0;       // start of Summer time if enabled Day 1- 7  (1- Sun)
-    uint16_t _dstStartMin = 0;     // start of Summer time if enabled in minutes
+    int16_t _dstStartMin = 0;     // start of Summer time if enabled in minutes
     uint8_t  _dstEndMonth = 0;       // end of Summer time if enabled  Month 1 - 12
     uint8_t  _dstEndWeek = 0;        // end of Summer time if enabled Week 1 - 5: (5 means last)
     uint8_t  _dstEndDay = 0;         // end of Summer time if enabled Day 1-7  (1- Sun)
-    uint16_t _dstEndMin = 0;       // end of Summer time if enabled in minutes
+    int16_t _dstEndMin = 0;       // end of Summer time if enabled in minutes
     bool     _useDST = false;      // currently using DST offset from _tz
     char* _ntpServerName;       ///< Name of NTP server on Internet or LAN
     int _shortInterval = DEFAULT_NTP_SHORTINTERVAL;         ///< Interval to set periodic time sync until first synchronization.

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -205,10 +205,12 @@ public:
 		      uint8_t dstStartMonth = 1,     // start of Summer time if enabled  Month 1 - 12, 0 disabled dst
 		      uint8_t dstStartWeek = 1,      // start of Summer time if enabled Week 1 - 5: (5 means last)
 		      uint8_t dstStartDay = 1,       // start of Summer time if enabled Day 0- 6  (0- Sun)
+		      // if startDay == 7, then sum of (StartMonth+StartWeek) is the day of the year DST starts
 		      uint16_t dstStartMin = 0,     // start of Summer time if enabled in minutes
 		      uint8_t dstEndMonth = 1,       // end of Summer time if enabled  Month 1 - 12
 		      uint8_t dstEndWeek = 1,        // end of Summer time if enabled Week 1 - 5: (5 means last)
 		      uint8_t dstEndDay = 1,         // end of Summer time if enabled Day 0-6  (0- Sun)
+		      // if EndDay == 7, then sum of (EndMonth+EndWeek) is the day of the year DST ends
 		      uint16_t dstEndMin = 0);       // end of Summer time if enabled in minutes
 
     /**

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -193,6 +193,25 @@ public:
     bool setTimeZone (int8_t timeZone, int8_t minutes = 0);
 
     /**
+    * Sets timezone.
+    * @param[out] 0 if everything went ok.
+    */
+
+    int setTimeZone (
+		      int16_t  timeZoneOffset,     // full offset from GMT 0 in minutes 
+		      char * timeZoneName = NULL,
+		      char * timeZoneDSTName = NULL,    // NULL if disable
+		      int16_t  timeZoneDSTOffset = 1,  // full offset from GMT 0 in minutes  for DST
+		      uint8_t dstStartMonth = 1,     // start of Summer time if enabled  Month 1 - 12, 0 disabled dst
+		      uint8_t dstStartWeek = 1,      // start of Summer time if enabled Week 1 - 5: (5 means last)
+		      uint8_t dstStartDay = 1,       // start of Summer time if enabled Day 0- 6  (0- Sun)
+		      uint16_t dstStartMin = 0,     // start of Summer time if enabled in minutes
+		      uint8_t dstEndMonth = 1,       // end of Summer time if enabled  Month 1 - 12
+		      uint8_t dstEndWeek = 1,        // end of Summer time if enabled Week 1 - 5: (5 means last)
+		      uint8_t dstEndDay = 1,         // end of Summer time if enabled Day 0-6  (0- Sun)
+		      uint16_t dstEndMin = 0);       // end of Summer time if enabled in minutes
+
+    /**
     * Gets timezone.
     * @param[out] Time offset in hours (plus or minus).
     */
@@ -205,9 +224,21 @@ public:
     int8_t getTimeZoneMinutes ();
 
     /**
+    * Gets DST start date
+    * @param[out] DST start date and time.
+    */
+    time_t getDstStart ();
+
+    /**
+    * Gets DST end date
+    * @param[out] DST end date and time.
+    */
+    time_t getDstEnd ();
+    /**
     * Stops time synchronization.
     * @param[out] True if everything went ok.
     */
+
     bool stop ();
 
     /**
@@ -301,6 +332,14 @@ public:
     String getTimeDateString (time_t moment);
 
     /**
+    * Convert current date and time to a String.
+    * @param[in] time_t object to convert to String.
+    * @param[out] String constructed from current time.
+    * TODO: Add internationalization support
+    */
+    String getDateTimeString (time_t moment);
+
+    /**
     * Gets last successful sync time in UNIX format.
     * @param[out] Last successful sync time. 0 equals never.
     */
@@ -343,8 +382,8 @@ public:
     * @param[out] True = summertime enabled and time in summertime period
     *			  False = sumertime disabled or time ouside summertime period
     */
-    boolean isSummerTime () {
-        if (_daylight)
+    bool isSummerTime () {
+        if (_tzDSTName != NULL)
             return isSummerTimePeriod (now ());
         else
             return false;
@@ -356,8 +395,17 @@ public:
     * @param[out] True = time in summertime period
     *			  False = time ouside summertime period
     */
-    boolean isSummerTimePeriod (time_t moment);
+    bool isSummerTimePeriod (time_t moment);
 
+    /**
+     * return true if currently using DST offset
+    */
+    bool inSummerTime () { return _useDST; }
+
+    /**
+     * return the current offset to GMT in minutes;
+    */
+    int16_t getOffset ();
 protected:
 
 #if NETWORK_TYPE == NETWORK_W5100
@@ -365,9 +413,22 @@ protected:
 #elif NETWORK_TYPE == NETWORK_ESP8266 || NETWORK_TYPE == NETWORK_WIFI101 || NETWORK_TYPE == NETWORK_ESP32
     WiFiUDP *udp;
 #endif
-    bool _daylight;             ///< Does this time zone have daylight saving?
-    int8_t _timeZone = 0;       ///< Keep track of set time zone offset
-    int8_t _minutesOffset = 0;   ///< Minutes offset for time zones with decimal numbers
+  // bool _daylight;             ///< Does this time zone have daylight saving?
+  // int8_t _timeZone = 0;       ///< Keep track of set time zone offset
+    //   int8_t _minutesOffset = 0;   ///< Minutes offset for time zones with decimal numbers
+    int16_t  _tzOffset;     // offset from GMT 0 in minutes 
+    char *   _tzName = NULL;
+    char *   _tzDSTName = NULL;    // NULL if disable
+    int16_t  _tzDSTOffset = 0;  // offset from GMT 0 in minutes 
+    uint8_t  _dstStartMonth = 0;     // start of Summer time if enabled  Month 1 - 12, 0 disabled dst
+    uint8_t  _dstStartWeek = 0;      // start of Summer time if enabled Week 1 - 5: (5 means last)
+    uint8_t  _dstStartDay = 0;       // start of Summer time if enabled Day 1- 7  (1- Sun)
+    uint16_t _dstStartMin = 0;     // start of Summer time if enabled in minutes
+    uint8_t  _dstEndMonth = 0;       // end of Summer time if enabled  Month 1 - 12
+    uint8_t  _dstEndWeek = 0;        // end of Summer time if enabled Week 1 - 5: (5 means last)
+    uint8_t  _dstEndDay = 0;         // end of Summer time if enabled Day 1-7  (1- Sun)
+    uint16_t _dstEndMin = 0;       // end of Summer time if enabled in minutes
+    bool     _useDST = false;      // currently using DST offset from _tz
     char* _ntpServerName;       ///< Name of NTP server on Internet or LAN
     int _shortInterval;         ///< Interval to set periodic time sync until first synchronization.
     int _longInterval;          ///< Interval to set periodic time sync
@@ -388,10 +449,9 @@ protected:
     * @param[in] Month.
     * @param[in] Day.
     * @param[in] Hour.
-    * @param[in] Time zone offset.
     * @param[out] true if date and time are inside summertime period.
     */
-    bool summertime (int year, byte month, byte day, byte hour, byte tzHours);
+    bool summertime (int year, byte month, byte day, byte hour);
 
     /**
     * Helper function to add leading 0 to hour, minutes or seconds if < 10.

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -66,10 +66,10 @@ using namespace placeholders;
 
 #define DEFAULT_NTP_SERVER "pool.ntp.org" // Default international NTP server. I recommend you to select a closer server to get better accuracy
 #define DEFAULT_NTP_PORT 123 // Default local udp port. Select a different one if neccesary (usually not needed)
-#define NTP_TIMEOUT 1500 // Response timeout for NTP requests
 #define DEFAULT_NTP_INTERVAL 1800 // Default sync interval 30 minutes 
 #define DEFAULT_NTP_SHORTINTERVAL 15 // Sync interval when sync has not been achieved. 15 seconds
 #define DEFAULT_NTP_TIMEZONE 0 // Select your local time offset. 0 if UTC time has to be used
+#define MIN_NTP_TIMEOUT 100 // Minumum admisible ntp timeout
 
 const int NTP_PACKET_SIZE = 48; // NTP time is in the first 48 bytes of message
 
@@ -370,6 +370,18 @@ public:
     time_t getFirstSync ();
 
     /**
+    * Get configured response timeout for NTP requests.
+    * @param[out] NTP Timeout.
+    */
+    uint16_t getNTPTimeout ();
+
+    /**
+    * Configure response timeout for NTP requests.
+    * @param[out] error code. false if faulty.
+    */
+    boolean setNTPTimeout (uint16_t milliseconds);
+
+    /**
     * Set a callback that triggers after a sync trial.
     * @param[in] function with void(NTPSyncEvent_t) or std::function<void(NTPSyncEvent_t)> (only for ESP8266)
     *				NTPSyncEvent_t equals 0 is there is no error
@@ -406,6 +418,7 @@ public:
      * return the current offset to GMT in minutes;
     */
     int16_t getOffset ();
+
 protected:
 
 #if NETWORK_TYPE == NETWORK_W5100
@@ -430,11 +443,12 @@ protected:
     uint16_t _dstEndMin = 0;       // end of Summer time if enabled in minutes
     bool     _useDST = false;      // currently using DST offset from _tz
     char* _ntpServerName;       ///< Name of NTP server on Internet or LAN
-    int _shortInterval;         ///< Interval to set periodic time sync until first synchronization.
-    int _longInterval;          ///< Interval to set periodic time sync
+    int _shortInterval = DEFAULT_NTP_SHORTINTERVAL;         ///< Interval to set periodic time sync until first synchronization.
+    int _longInterval = DEFAULT_NTP_INTERVAL;          ///< Interval to set periodic time sync
     time_t _lastSyncd = 0;      ///< Stored time of last successful sync
     time_t _firstSync = 0;      ///< Stored time of first successful sync after boot
     unsigned long _uptime = 0;  ///< Time since boot
+    uint16_t ntpTimeout = 1500; ///< Response timeout for NTP requests
     onSyncEvent_t onSyncEvent;  ///< Event handler callback
 
     /**


### PR DESCRIPTION
Save start/end  {month(1-13),week(1-5),day(0-6),name} for a time zone as can be extracts for a posix database https://raw.githubusercontent.com/nayarsystems/posix_tz_db/master/zones.csv

Extraction  of this data is left to the user of the library.

Save actually UTC time offset in total minutes (instead of hours and minutes). Track whether or not current time is use DST zone  offset or base zone offset.

include the zone name in the string for the current time if it is set (backwards compatible).
In a DST zone name is no provide, then  the current time zone does not has a DST mode.
