### PR TITLE
Fixed a compilation error due to type ambiguity (ambiguous overload)

### DIFF
--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -221,7 +221,7 @@ void NTPClient::dnsFound (const ip_addr_t *ipaddr) {
     responseTimer2.detach ();
     ntpServerIPAddress = getIPClass (ipaddr);
     DEBUGLOG ("%s - %s\n", __FUNCTION__, ntpServerIPAddress.toString ().c_str ());
-    if (ipaddr != NULL && ntpServerIPAddress != 0)
+    if (ipaddr != NULL && ntpServerIPAddress != (uint32_t)(0))
       setTime (getTime ());
 }
 


### PR DESCRIPTION
Fixed the following error, occurring when attempting to compile a sketch with the library included:

C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp: In member function 'void NTPClient::dnsFound(const ip4_addr*)':

C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:224:46: error: ambiguous overload for 'operator!=' (operand types are 'IPAddress' and 'int')

 if (ipaddr != NULL && ntpServerIPAddress != 0)//(uint32_t)(0))

                                          ^
C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:224:46: note: candidates are:

C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:224:46: note: operator!=(uint32_t {aka unsigned int}, int)

C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:224:46: note: operator!=(u32_t {aka long unsigned int}, int)

C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:224:46: note: operator!=(int, int)

C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:224:46: note: operator!=(const ip_addr_t* {aka const ip4_addr*}, const ip_addr_t* {aka const ip4_addr*})

C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:224:46: note: operator!=(ip_addr_t* {aka ip4_addr*}, ip_addr_t* {aka ip4_addr*})

In file included from C:\Users\jeany\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\2.5.0\libraries\ESP8266WiFi\src/ESP8266WiFi.h:31:0,

           from C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NtpClientLib.h:104,

           from C:\Users\jeany\Documents\Arduino\libraries\NtpClient-develop\src\NTPClientLib.cpp:32:
C:\Users\jeany\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\2.5.0\cores\esp8266/IPAddress.h:106:14: note: bool IPAddress::operator!=(const IPAddress&) const

     bool operator!=(const IPAddress& addr) const {

          ^
C:\Users\jeany\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\2.5.0\cores\esp8266/IPAddress.h:115:14: note: bool IPAddress::operator!=(uint32_t) const

     bool operator!=(uint32_t addr) const {

          ^
C:\Users\jeany\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\2.5.0\cores\esp8266/IPAddress.h:118:14: note: bool IPAddress::operator!=(u32_t) const

     bool operator!=(u32_t addr) const {

          ^
exit status 1
Error compiling for board NodeMCU 1.0 (ESP-12E Module).