### PR TITLE
Add includes for lwip1.4

### DIFF
--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -46,6 +46,8 @@ using namespace std;
 using namespace placeholders;
 
 extern "C" {
+#include "lwip/init.h"
+#include "lwip/ip_addr.h"
 #include "lwip/err.h"
 #include "lwip/dns.h"
 }


### PR DESCRIPTION
Pre-req
```
$ export PLATFORMIO_BUILD_FLAGS="-DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH"
$ export PLATFORMIO_CI_SRC=examples/NTPClientESP8266/NTPClientESP8266.ino
```
When trying to build:
```
$ pio ci --lib . --lib examples/NTPClientESP8266/ -b d1_mini
...
In file included from lib/NtpClient/src/NtpClientLib.h:50:0,
from /tmp/tmp4GB_tD/src/NTPClientESP8266.ino:38:
/home/builder/.platformio/packages/framework-arduinoespressif8266/tools/sdk/lwip/include/lwip/dns.h:104:54: error: 'ip_addr_t' has not been declared
typedef void (*dns_found_callback)(const char *name, ip_addr_t *ipaddr, void *callback_arg);
^
/home/builder/.platformio/packages/framework-arduinoespressif8266/tools/sdk/lwip/include/lwip/dns.h:108:43: error: 'ip_addr_t' has not been declared
void           dns_setserver(u8_t numdns, ip_addr_t *dnsserver);
^
/home/builder/.platformio/packages/framework-arduinoespressif8266/tools/sdk/lwip/include/lwip/dns.h:109:1: error: 'ip_addr_t' does not name a type
ip_addr_t      dns_getserver(u8_t numdns);
^
/home/builder/.platformio/packages/framework-arduinoespressif8266/tools/sdk/lwip/include/lwip/dns.h:110:56: error: 'ip_addr_t' has not been declared
err_t          dns_gethostbyname(const char *hostname, ip_addr_t *addr,
^
```