### PR TITLE
Dependency specific for ESP8266

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,11 +9,12 @@
     [{
 	  "name": "Time",
 	  "authors": "Paul Stoffregen",
-	  "version": "^5.10"
+	  "version": "^1.50"
 	},
 	{
 	  "name": "ESPAsyncUDP",
-	  "authors": "Hristo Gochkov"
+	  "authors": "Hristo Gochkov",
+	  "platform": "espressif8266"
 	}],
   "url": "https://github.com/gmag11/NtpClient",
   "authors":


### PR DESCRIPTION
ESP32 does not compile on PlatformIO with a reference to ESPAsyncUDP, as one of the sub-referenced libraries - user_interface.h - does not exist for ESP32.