### PR TITLE
type mismatche

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,7 +14,7 @@
     {
       "name": "ESPAsyncUDP",
       "authors": "Hristo Gochkov",
-      "platforms": ["espressif", "espresif8266"]
+      "platforms": ["espressif8266"]
 	}],
   "url": "https://github.com/gmag11/NtpClient",
   "authors":


### PR DESCRIPTION
missed ‘s’ in espreSsIf
use possible entries based on https://docs.platformio.org/en/latest/platforms/index.html#platforms