### PR TITLE
Option to get the sync Status. 

### DIFF
--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -220,6 +220,15 @@ IPAddress getIPClass (const ip_addr_t *ipaddr) {
     return ip;
 }
 
+boolean NTPClient::SyncStatus(){
+	
+	if (status==syncd) {
+		return true;
+	}
+	return false;
+	
+}
+
 void NTPClient::dnsFound (const ip_addr_t *ipaddr) {
     //IPAddress ip;
 

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -38,7 +38,7 @@ or implied, of German Martin
 #ifndef _NtpClientLib_h
 #define _NtpClientLib_h
 
-//#define DEBUG_NTPCLIENT //Uncomment this to enable debug messages over serial port
+#define DEBUG_NTPCLIENT //Uncomment this to enable debug messages over serial port
 
 #if defined ESP8266 || defined ESP32
 #include <functional>
@@ -422,6 +422,8 @@ public:
     *			  False = time ouside summertime period
     */
     boolean isSummerTimePeriod (time_t moment);
+	
+	boolean SyncStatus();
 
 protected:
 


### PR DESCRIPTION
By using asyncUDP, the library no longer blocks the main code. With time-critical scripts, it may happen that the time has not yet been updated, but it must already be worked with. Now it is possible to "block" until its synced.