### PR TITLE
Fix `byte` issue, other warnings and deprecation

### DIFF
--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -254,7 +254,7 @@ void  NTPClient::processDNSTimeout () {
         onSyncEvent (invalidAddress);
 }
 
-void ICACHE_RAM_ATTR NTPClient::s_processDNSTimeout (void* arg) {
+void IRAM_ATTR NTPClient::s_processDNSTimeout (void* arg) {
     reinterpret_cast<NTPClient*>(arg)->processDNSTimeout ();
 }
 #endif
@@ -428,7 +428,7 @@ void NTPClient::processPacket (AsyncUDPPacket& packet) {
     DEBUGLOG ("\n");
 }
 
-void ICACHE_RAM_ATTR NTPClient::processRequestTimeout () {
+void IRAM_ATTR NTPClient::processRequestTimeout () {
     status = unsyncd;
     //timer1_disable ();
     responseTimer.detach ();
@@ -437,7 +437,7 @@ void ICACHE_RAM_ATTR NTPClient::processRequestTimeout () {
         onSyncEvent (noResponse);
 }
 
-void ICACHE_RAM_ATTR NTPClient::s_processRequestTimeout (void* arg) {
+void IRAM_ATTR NTPClient::s_processRequestTimeout (void* arg) {
     NTPClient* self = reinterpret_cast<NTPClient*>(arg);
     self->processRequestTimeout ();
 }

--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -303,7 +303,7 @@ time_t NTPClient::getTime () {
 			return 0;
 		}
         if (udp->connect (ntpServerIPAddress, DEFAULT_NTP_PORT)) {
-            udp->onPacket (std::bind (&NTPClient::processPacket, this, _1));
+            udp->onPacket (std::bind (&NTPClient::processPacket, this, std::placeholders::_1));
             DEBUGLOG ("%s - Sending UDP packet\n", __FUNCTION__);
             if (sendNTPpacket (udp)) {
                 DEBUGLOG ("%s - NTP request sent\n", __FUNCTION__);

--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -199,6 +199,7 @@ time_t NTPClient::getTime () {
 }
 #elif NETWORK_TYPE == NETWORK_ESP8266 || NETWORK_TYPE == NETWORK_ESP32
 void NTPClient::s_dnsFound (const char *name, const ip_addr_t *ipaddr, void *callback_arg) {
+    (void)name;
     reinterpret_cast<NTPClient*>(callback_arg)->dnsFound (ipaddr);
 }
 
@@ -335,6 +336,7 @@ time_t NTPClient::getTime () {
 }
 
 void dumpNTPPacket (byte *data, size_t length) {
+    (void)data;
     //byte *data = packet.data ();
     //size_t length = packet.length ();
 
@@ -695,6 +697,7 @@ bool NTPClient::summertime (int year, byte month, byte day, byte hour, byte week
 }
 
 boolean NTPClient::isSummerTimePeriod (time_t moment) {
+    (void)moment;
     return summertime (year (), month (), day (), hour (), weekday (), getTimeZone ());
 }
 

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -42,8 +42,6 @@ or implied, of German Martin
 
 #if defined ESP8266 || defined ESP32
 #include <functional>
-using namespace std;
-using namespace placeholders;
 
 extern "C" {
 #include "lwip/init.h"

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -49,6 +49,11 @@ extern "C" {
 #include "lwip/err.h"
 #include "lwip/dns.h"
 }
+
+#ifndef IRAM_ATTR
+#define IRAM_ATTR ICACHE_RAM_ATTR
+#endif
+
 #endif
 
 #include <TimeLib.h>
@@ -473,16 +478,16 @@ protected:
     /**
     * Process internal state in case of a response timeout. If a response comes later is is asumed as non valid.
     */
-    void ICACHE_RAM_ATTR processRequestTimeout ();
+    void IRAM_ATTR processRequestTimeout ();
 
     /**
     * Static method for Ticker argument.
     */
-    static void ICACHE_RAM_ATTR s_processRequestTimeout (void* arg);
+    static void IRAM_ATTR s_processRequestTimeout (void* arg);
 
     static void s_dnsFound (const char *name, const ip_addr_t *ipaddr, void *callback_arg);
     void dnsFound (const ip_addr_t *ipaddr);
-    static void ICACHE_RAM_ATTR s_processDNSTimeout (void* arg);
+    static void IRAM_ATTR s_processDNSTimeout (void* arg);
     void processDNSTimeout ();
 
 #endif


### PR DESCRIPTION
These changes are backward compatible with older cores.
They will:
- remove warnings
- honor deprecation (esp8266 Arduino core v3+)
- related: https://github.com/esp8266/Arduino/issues/8089 (c++17)